### PR TITLE
Add chunked and resumable CLI densification

### DIFF
--- a/core/camera_models.py
+++ b/core/camera_models.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
 
@@ -19,6 +19,7 @@ class CameraRecord:
     P: np.ndarray
     C: np.ndarray
     mask_path: Optional[str] = None
+    colmap_camera: Optional[Any] = None
 
     def flat_pose(self) -> np.ndarray:
         """Return flattened 4x4 pose for clustering/nearest neighbors."""

--- a/core/geometry.py
+++ b/core/geometry.py
@@ -1,12 +1,29 @@
 """Geometry helpers for densification pipeline."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import numpy as np
 
 if TYPE_CHECKING:
     import pycolmap
+
+PINHOLE_CAMERA_MODELS = {"PINHOLE", "SIMPLE_PINHOLE"}
+
+
+def camera_model_name(cam: Optional[pycolmap.Camera]) -> str:
+    if cam is None:
+        return ""
+    try:
+        return str(cam.model.name).upper()
+    except Exception:
+        return str(getattr(cam, "model", "")).upper()
+
+
+def uses_distortion_aware_projection(cam: Optional[pycolmap.Camera]) -> bool:
+    """Return True when a COLMAP camera should not be reduced to a pinhole K matrix."""
+    model = camera_model_name(cam)
+    return bool(model) and model not in PINHOLE_CAMERA_MODELS
 
 
 def K_from_camera(cam: pycolmap.Camera) -> np.ndarray:
@@ -46,6 +63,10 @@ def pose_world2cam(im: pycolmap.Image) -> Tuple[np.ndarray, np.ndarray]:
 
 def P_from_KRt(K: np.ndarray, R: np.ndarray, t: np.ndarray) -> np.ndarray:
     return K @ np.concatenate([R, t], axis=1)
+
+
+def Rt_from_Rt(R: np.ndarray, t: np.ndarray) -> np.ndarray:
+    return np.concatenate([R, t], axis=1).astype(np.float32, copy=False)
 
 
 def cam_center_world(R: np.ndarray, t: np.ndarray) -> np.ndarray:
@@ -106,9 +127,63 @@ def reprojection_errors(P: np.ndarray, X: np.ndarray, uv: np.ndarray) -> np.ndar
     return np.sqrt(du * du + dv * dv)
 
 
+def unproject_pixels(cam: pycolmap.Camera, uv: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Unproject image pixels to COLMAP normalized camera coordinates.
+
+    ``pycolmap.Camera.cam_from_img`` applies the camera model, including
+    distortion/fisheye terms such as THIN_PRISM_FISHEYE. The returned 2D
+    coordinates live on the normalized camera plane and can be triangulated
+    with a plain [R|t] camera matrix.
+    """
+    uv64 = np.asarray(uv, dtype=np.float64)
+    out = cam.cam_from_img(uv64)
+    if out is None:
+        uv_cam = np.full((uv64.shape[0], 2), np.nan, dtype=np.float32)
+    else:
+        uv_cam = np.asarray(out, dtype=np.float32).reshape(-1, 2)
+    valid = np.isfinite(uv_cam).all(axis=1)
+    return uv_cam, valid
+
+
+def reprojection_errors_camera(
+    cam: pycolmap.Camera,
+    R: np.ndarray,
+    t: np.ndarray,
+    X: np.ndarray,
+    uv: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Project world points with a full COLMAP camera model and compare in pixels."""
+    X3 = np.asarray(X[:, :3], dtype=np.float64)
+    R64 = np.asarray(R, dtype=np.float64)
+    t64 = np.asarray(t, dtype=np.float64).reshape(1, 3)
+    X_cam = X3 @ R64.T + t64
+    try:
+        uv_pred_raw = cam.img_from_cam(X_cam)
+    except Exception:
+        uv_pred_raw = None
+
+    if uv_pred_raw is None:
+        uv_pred = np.full((X3.shape[0], 2), np.nan, dtype=np.float32)
+    else:
+        uv_pred = np.asarray(uv_pred_raw, dtype=np.float32).reshape(-1, 2)
+
+    valid = np.isfinite(uv_pred).all(axis=1) & (X_cam[:, 2] > 0.0)
+    du = uv_pred[:, 0] - uv[:, 0]
+    dv = uv_pred[:, 1] - uv[:, 1]
+    err = np.sqrt(du * du + dv * dv).astype(np.float32)
+    err[~valid] = np.inf
+    return err, valid
+
+
 def cheirality_mask(P: np.ndarray, X: np.ndarray) -> np.ndarray:
     Xh = X.T
     z = (P @ Xh)[2, :]
+    return z > 0.0
+
+
+def cheirality_mask_Rt(R: np.ndarray, t: np.ndarray, X: np.ndarray) -> np.ndarray:
+    X3 = np.asarray(X[:, :3], dtype=np.float32)
+    z = X3 @ R[2, :].T + float(np.asarray(t).reshape(3)[2])
     return z > 0.0
 
 

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -16,12 +16,18 @@ from PIL import Image
 from .camera_models import CameraRecord
 from .config import DensePipelineConfig
 from .geometry import (
+    Rt_from_Rt,
     cheirality_mask,
+    cheirality_mask_Rt,
+    camera_model_name,
     dlt_triangulate_batch,
     fundamental_from_world2cam,
     parallax_mask,
+    reprojection_errors_camera,
     reprojection_errors,
     sampson_error,
+    unproject_pixels,
+    uses_distortion_aware_projection,
 )
 from .image_utils import apply_mask_to_rgb, load_mask_resized_np, load_rgb_resized, to_uint8_rgb
 from .debug_viz import MatchPreview, MatchDebugState
@@ -76,6 +82,8 @@ class _CameraLookup:
     t_by: Dict[int, np.ndarray]
     P_by: Dict[int, np.ndarray]
     C_by: Dict[int, np.ndarray]
+    colmap_camera_by: Dict[int, object]
+    distortion_aware_by: Dict[int, bool]
 
 
 @dataclass(frozen=True)
@@ -281,6 +289,11 @@ def _build_camera_lookup(camera_records: List[CameraRecord]) -> _CameraLookup:
         t_by={cam.uid: cam.t for cam in camera_records},
         P_by={cam.uid: cam.P for cam in camera_records},
         C_by={cam.uid: cam.C for cam in camera_records},
+        colmap_camera_by={cam.uid: cam.colmap_camera for cam in camera_records if cam.colmap_camera is not None},
+        distortion_aware_by={
+            cam.uid: uses_distortion_aware_projection(cam.colmap_camera)
+            for cam in camera_records
+        },
     )
 
 
@@ -630,6 +643,8 @@ def _triangulate_ref(
     t_by = cameras.t_by
     P_by = cameras.P_by
     C_by = cameras.C_by
+    colmap_camera_by = cameras.colmap_camera_by
+    distortion_aware_by = cameras.distortion_aware_by
 
     warp_list = matched_ref.warp_list_cpu
     cert_list = matched_ref.cert_list_cpu
@@ -711,7 +726,12 @@ def _triangulate_ref(
         yA_pair = yA
         cert_pair = selected_certs[kidx]
 
-        if (not config.no_filter) and config.sampson_thresh > 0:
+        pair_uses_distortion_aware = bool(
+            distortion_aware_by.get(ref_id, False)
+            or distortion_aware_by.get(nbr_id, False)
+        )
+
+        if (not pair_uses_distortion_aware) and (not config.no_filter) and config.sampson_thresh > 0:
             F = fundamental_from_world2cam(
                 K_by[ref_id],
                 R_by[ref_id],
@@ -734,23 +754,70 @@ def _triangulate_ref(
         if idxs.size == 0:
             continue
 
-        P1, P2 = P_by[ref_id], P_by[nbr_id]
         uvA = uvA_full[idxs]
-        Xi = dlt_triangulate_batch(P1, P2, uvA, uvB)
+        P1, P2 = P_by[ref_id], P_by[nbr_id]
 
-        err1 = reprojection_errors(P1, Xi, uvA)
-        err2 = reprojection_errors(P2, Xi, uvB)
-        err = np.maximum(err1, err2)
+        if pair_uses_distortion_aware:
+            cam1 = colmap_camera_by.get(ref_id)
+            cam2 = colmap_camera_by.get(nbr_id)
+            if cam1 is None or cam2 is None:
+                lf.log.warn(
+                    "Distortion-aware triangulation requested but COLMAP camera "
+                    f"metadata is missing for pair {ref_id}->{nbr_id}; skipping pair."
+                )
+                continue
+
+            uvA_cam, validA = unproject_pixels(cam1, uvA)
+            uvB_cam, validB = unproject_pixels(cam2, uvB)
+            valid_uv = validA & validB
+            if not np.any(valid_uv):
+                continue
+
+            uvA_used = uvA[valid_uv]
+            uvB_used = uvB[valid_uv]
+            uvA_cam = uvA_cam[valid_uv]
+            uvB_cam = uvB_cam[valid_uv]
+            xA_pair = xA_pair[valid_uv]
+            yA_pair = yA_pair[valid_uv]
+            xB = xB[valid_uv]
+            yB = yB[valid_uv]
+            cert_pair = cert_pair[valid_uv]
+            rgb_used = rgb_ref[idxs][valid_uv]
+
+            Rt1 = Rt_from_Rt(R_by[ref_id], t_by[ref_id])
+            Rt2 = Rt_from_Rt(R_by[nbr_id], t_by[nbr_id])
+            Xi = dlt_triangulate_batch(Rt1, Rt2, uvA_cam, uvB_cam)
+
+            err1, valid_proj1 = reprojection_errors_camera(
+                cam1, R_by[ref_id], t_by[ref_id], Xi, uvA_used
+            )
+            err2, valid_proj2 = reprojection_errors_camera(
+                cam2, R_by[nbr_id], t_by[nbr_id], Xi, uvB_used
+            )
+            err = np.maximum(err1, err2)
+            projection_valid = valid_proj1 & valid_proj2
+            cheirality_valid = cheirality_mask_Rt(R_by[ref_id], t_by[ref_id], Xi)
+            cheirality_valid &= cheirality_mask_Rt(R_by[nbr_id], t_by[nbr_id], Xi)
+        else:
+            Xi = dlt_triangulate_batch(P1, P2, uvA, uvB)
+
+            err1 = reprojection_errors(P1, Xi, uvA)
+            err2 = reprojection_errors(P2, Xi, uvB)
+            err = np.maximum(err1, err2)
+            projection_valid = np.isfinite(err)
+            cheirality_valid = cheirality_mask(P1, Xi)
+            cheirality_valid &= cheirality_mask(P2, Xi)
+            rgb_used = rgb_ref[idxs]
 
         if config.no_filter:
-            finite_mask = np.isfinite(Xi).all(axis=1) & np.isfinite(err)
+            finite_mask = np.isfinite(Xi).all(axis=1) & np.isfinite(err) & projection_valid
             if not np.any(finite_mask):
                 continue
             keep = finite_mask
         else:
-            keep = err <= float(config.reproj_thresh)
-            keep &= cheirality_mask(P1, Xi)
-            keep &= cheirality_mask(P2, Xi)
+            keep = np.isfinite(Xi).all(axis=1) & projection_valid
+            keep &= err <= float(config.reproj_thresh)
+            keep &= cheirality_valid
             if config.min_parallax_deg > 0:
                 keep &= parallax_mask(C_by[ref_id], C_by[nbr_id], Xi, min_deg=config.min_parallax_deg)
             if not np.any(keep):
@@ -797,6 +864,21 @@ def _triangulate_ref(
     out_err: List[float] = []
     out_tracks: List[List[Tuple[int, float, float]]] = []
 
+    def support_reprojection_error(image_id: int, Xh_point: np.ndarray, uv_obs: np.ndarray) -> float:
+        if distortion_aware_by.get(image_id, False):
+            cam = colmap_camera_by.get(image_id)
+            if cam is None:
+                return float("inf")
+            err_cam, _valid = reprojection_errors_camera(
+                cam,
+                R_by[image_id],
+                t_by[image_id],
+                Xh_point[None, :],
+                uv_obs[None, :],
+            )
+            return float(err_cam[0])
+        return float(reprojection_errors(P_by[image_id], Xh_point[None, :], uv_obs[None, :])[0])
+
     for sample_idx, candidates in enumerate(candidates_by_sample):
         if not candidates:
             continue
@@ -808,7 +890,7 @@ def _triangulate_ref(
         Xh = np.concatenate([Xw.astype(np.float32), np.ones((1,), dtype=np.float32)])
 
         ref_obs = uvA_full[sample_idx]
-        ref_err = reprojection_errors(P_by[ref_id], Xh[None, :], ref_obs[None, :])[0]
+        ref_err = support_reprojection_error(ref_id, Xh, ref_obs)
         if not config.no_filter and (not np.isfinite(ref_err) or ref_err > float(config.reproj_thresh)):
             continue
 
@@ -834,11 +916,11 @@ def _triangulate_ref(
             ) = candidate
             if nbr_id in used_images:
                 continue
-            nbr_err = reprojection_errors(
-                P_by[nbr_id],
-                Xh[None, :],
-                np.asarray([[uvb_x, uvb_y]], dtype=np.float32),
-            )[0]
+            nbr_err = support_reprojection_error(
+                nbr_id,
+                Xh,
+                np.asarray([uvb_x, uvb_y], dtype=np.float32),
+            )
             if not config.no_filter and (not np.isfinite(nbr_err) or nbr_err > float(config.reproj_thresh)):
                 continue
             used_images.add(nbr_id)
@@ -895,6 +977,25 @@ def run_dense_pipeline(
     np.random.seed(config.seed)
 
     cameras = _build_camera_lookup(camera_records)
+    distortion_models = sorted(
+        {
+            camera_model_name(cameras.colmap_camera_by[uid])
+            for uid, enabled in cameras.distortion_aware_by.items()
+            if enabled and uid in cameras.colmap_camera_by
+        }
+    )
+    if distortion_models:
+        msg = "Distortion-aware COLMAP projection enabled: " + ", ".join(distortion_models)
+        lf.log.info(msg)
+        if progress_callback is not None:
+            progress_callback(3.0, msg)
+        if config.sampson_thresh > 0:
+            lf.log.info(
+                "Sampson pre-filter is skipped for distortion-aware camera pairs; "
+                "reprojection, cheirality, and parallax filters remain active."
+            )
+            if progress_callback is not None:
+                progress_callback(4.0, "Sampson filter skipped for distorted/fisheye camera pairs")
     total_pairs_est = _estimate_total_pairs(refs_local, nn_table, cameras.img_ids, config.nns_per_ref)
     if debug_state:
         debug_state.set_total_pairs(total_pairs_est)

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -773,8 +773,11 @@ def _triangulate_ref(
             if not np.any(valid_uv):
                 continue
 
-            uvA_used = uvA[valid_uv]
-            uvB_used = uvB[valid_uv]
+            idxs = idxs[valid_uv]
+            uvA = uvA[valid_uv]
+            uvB = uvB[valid_uv]
+            uvA_used = uvA
+            uvB_used = uvB
             uvA_cam = uvA_cam[valid_uv]
             uvB_cam = uvB_cam[valid_uv]
             xA_pair = xA_pair[valid_uv]
@@ -782,7 +785,7 @@ def _triangulate_ref(
             xB = xB[valid_uv]
             yB = yB[valid_uv]
             cert_pair = cert_pair[valid_uv]
-            rgb_used = rgb_ref[idxs][valid_uv]
+            rgb_used = rgb_ref[idxs]
 
             Rt1 = Rt_from_Rt(R_by[ref_id], t_by[ref_id])
             Rt2 = Rt_from_Rt(R_by[nbr_id], t_by[nbr_id])

--- a/densify.py
+++ b/densify.py
@@ -131,6 +131,8 @@ def _select_reference_indices(
     img_ids: List[int],
     num_refs: int,
 ) -> List[int]:
+    if num_refs >= len(img_ids):
+        return list(range(len(img_ids)))
     idx_map = {iid: i for i, iid in enumerate(img_ids)}
     try:
         refs = select_cameras_by_visibility(rec, num_refs)

--- a/densify.py
+++ b/densify.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import gc
 import os
 import sys
 import time
@@ -227,6 +228,241 @@ def _cancel_requested(cancel_requested: Optional[Callable[[], bool]]) -> bool:
         return False
 
 
+def _split_refs_local(refs_local: Sequence[int], chunk_count: int) -> List[List[int]]:
+    chunks = np.array_split(np.asarray(list(refs_local), dtype=np.int64), max(1, int(chunk_count)))
+    return [chunk.astype(np.int64).tolist() for chunk in chunks if chunk.size > 0]
+
+
+def _chunk_output_dir(output_path: str) -> str:
+    output = Path(output_path)
+    return str(output.with_suffix("")) + "_chunks"
+
+
+def _save_npz_chunk(path_out: str, xyz: np.ndarray, rgb: np.ndarray) -> int:
+    os.makedirs(os.path.dirname(path_out), exist_ok=True)
+    rgb_uint8 = to_uint8_rgb(rgb)
+    np.savez(path_out, xyz=xyz.astype(np.float32, copy=False), rgb=rgb_uint8)
+    return int(xyz.shape[0])
+
+
+def _npz_chunk_count(path_in: str) -> int:
+    with np.load(path_in) as data:
+        return int(data["xyz"].shape[0])
+
+
+def _write_ply_vertices(file_obj, xyz: np.ndarray, rgb_uint8: np.ndarray) -> None:
+    if xyz.shape[0] == 0:
+        return
+    if rgb_uint8.dtype != np.uint8:
+        rgb_uint8 = to_uint8_rgb(rgb_uint8)
+    packed = np.empty(
+        xyz.shape[0],
+        dtype=[
+            ("x", "<f4"),
+            ("y", "<f4"),
+            ("z", "<f4"),
+            ("red", "u1"),
+            ("green", "u1"),
+            ("blue", "u1"),
+        ],
+    )
+    xyz32 = xyz.astype(np.float32, copy=False)
+    packed["x"] = xyz32[:, 0]
+    packed["y"] = xyz32[:, 1]
+    packed["z"] = xyz32[:, 2]
+    packed["red"] = rgb_uint8[:, 0]
+    packed["green"] = rgb_uint8[:, 1]
+    packed["blue"] = rgb_uint8[:, 2]
+    packed.tofile(file_obj)
+
+
+def _write_ply_from_npz_chunks(
+    output_path: str,
+    chunk_paths: Sequence[str],
+    max_points: int,
+    seed: int,
+) -> Tuple[int, int]:
+    counts = [_npz_chunk_count(path) for path in chunk_paths]
+    total = int(sum(counts))
+    if total <= 0:
+        raise RuntimeError("No points remain after chunked densification.")
+
+    output_count = total
+    selected_global: Optional[np.ndarray] = None
+    if max_points > 0 and total > int(max_points):
+        output_count = int(max_points)
+        selected_global = np.sort(
+            np.random.default_rng(seed).choice(total, size=output_count, replace=False)
+        )
+
+    header = f"""ply
+format binary_little_endian 1.0
+element vertex {output_count}
+property float x
+property float y
+property float z
+property uchar red
+property uchar green
+property uchar blue
+end_header
+"""
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "wb") as f:
+        f.write(header.encode("ascii"))
+        global_offset = 0
+        selected_pos = 0
+        for path, count in zip(chunk_paths, counts):
+            if count <= 0:
+                continue
+            local_idx = None
+            if selected_global is not None:
+                start = selected_pos
+                while selected_pos < selected_global.size and selected_global[selected_pos] < global_offset + count:
+                    selected_pos += 1
+                if selected_pos == start:
+                    global_offset += count
+                    continue
+                local_idx = selected_global[start:selected_pos] - global_offset
+
+            with np.load(path) as data:
+                xyz = data["xyz"]
+                rgb = data["rgb"]
+                if local_idx is not None:
+                    xyz = xyz[local_idx]
+                    rgb = rgb[local_idx]
+                _write_ply_vertices(f, xyz, rgb)
+            global_offset += count
+
+    return output_count, total
+
+
+def _run_dense_pipeline_chunked(
+    records: List[CameraRecord],
+    refs_local: Sequence[int],
+    nn_table: np.ndarray,
+    config: DensePipelineConfig,
+    chunk_count: int,
+    max_points_per_batch: int,
+    progress_callback: Optional[Callable[[float, str], None]],
+    debug_state=None,
+    cancel_requested: Optional[Callable[[], bool]] = None,
+) -> int:
+    if not config.output_path.lower().endswith(".ply"):
+        raise RuntimeError("Chunked CLI densification currently supports PLY output only.")
+
+    from .core.pipeline import PipelineCancelled, run_dense_pipeline
+
+    chunks = _split_refs_local(refs_local, chunk_count)
+    chunk_dir = _chunk_output_dir(config.output_path)
+    os.makedirs(chunk_dir, exist_ok=True)
+    lf.log.info(
+        f"Chunked densification enabled: {len(chunks)} chunks, "
+        f"global refs={len(refs_local)}, neighbors remain global"
+    )
+    if progress_callback:
+        progress_callback(5.0, f"Chunked densification: {len(chunks)} chunks")
+
+    chunk_paths: List[str] = []
+    chunk_counts: List[int] = []
+    for chunk_idx, chunk_refs in enumerate(chunks, start=1):
+        if _cancel_requested(cancel_requested):
+            if progress_callback:
+                progress_callback(0.0, "Cancelled")
+            return 2
+
+        lf.log.info(
+            f"Chunk {chunk_idx}/{len(chunks)}: processing {len(chunk_refs)} reference views"
+        )
+
+        def chunk_progress(pct: float, msg: str, _idx=chunk_idx, _total=len(chunks)) -> None:
+            if progress_callback is None:
+                return
+            chunk_base = 5.0 + ((_idx - 1) / max(1, _total)) * 88.0
+            chunk_span = 88.0 / max(1, _total)
+            mapped_pct = chunk_base + (float(pct) / 100.0) * chunk_span
+            progress_callback(mapped_pct, f"Matching chunk {_idx}/{_total}: {msg}")
+
+        try:
+            result = run_dense_pipeline(
+                records,
+                chunk_refs,
+                nn_table,
+                config,
+                progress_callback=chunk_progress,
+                on_sequential_viz=None,
+                debug_state=debug_state,
+                cancel_requested=cancel_requested,
+            )
+        except PipelineCancelled:
+            if progress_callback:
+                progress_callback(0.0, "Cancelled")
+            return 2
+        except RuntimeError as exc:
+            lf.log.warn(f"Chunk {chunk_idx}/{len(chunks)} failed: {exc}")
+            gc.collect()
+            continue
+
+        tracks_before = [list(track) for track in result.tracks]
+        xyz, rgb, err, tracks = _apply_track_filter(
+            result.xyz,
+            result.rgb,
+            result.err,
+            result.tracks,
+            config.min_track_length,
+        )
+        _log_track_filter_stats(
+            f"Chunk {chunk_idx}/{len(chunks)} track filter",
+            tracks_before,
+            tracks,
+            config.min_track_length,
+        )
+        if xyz.shape[0] == 0:
+            lf.log.warn(f"Chunk {chunk_idx}/{len(chunks)} produced no points after filtering.")
+            continue
+
+        if max_points_per_batch > 0:
+            xyz, rgb, err, tracks = _apply_point_cap(
+                xyz,
+                rgb,
+                err,
+                tracks,
+                int(max_points_per_batch),
+                config.seed + chunk_idx,
+            )
+
+        chunk_path = os.path.join(chunk_dir, f"chunk_{chunk_idx:04d}.npz")
+        count = _save_npz_chunk(chunk_path, xyz, rgb)
+        chunk_paths.append(chunk_path)
+        chunk_counts.append(count)
+        lf.log.info(f"Chunk {chunk_idx}/{len(chunks)} saved {count:,} points -> {chunk_path}")
+
+        del result, tracks_before, xyz, rgb, err, tracks
+        gc.collect()
+
+    if not chunk_paths:
+        raise RuntimeError("No points remain after chunked densification.")
+
+    if progress_callback:
+        progress_callback(94.0, "Merging chunked point output...")
+    output_count, total_count = _write_ply_from_npz_chunks(
+        config.output_path,
+        chunk_paths,
+        config.max_points,
+        config.seed,
+    )
+    lf.log.info(
+        f"Chunked dense reconstruction finished: wrote {output_count:,}/{total_count:,} "
+        f"points from {len(chunk_paths)} chunks -> {config.output_path}"
+    )
+    lf.log.info(
+        "Chunk point counts: "
+        + ", ".join(f"{idx + 1}:{count:,}" for idx, count in enumerate(chunk_counts))
+    )
+    if progress_callback:
+        progress_callback(100.0, f"Done! {output_count:,} points")
+    return 0
+
+
 def dense_init(
     args,
     progress_callback: Optional[Callable[[float, str], None]] = None,
@@ -264,6 +500,19 @@ def dense_init(
         prefetch_packages=args.prefetch_packages,
         pack_workers=args.pack_workers,
     )
+
+    if int(getattr(args, "chunked_batches", 1)) > 1:
+        return _run_dense_pipeline_chunked(
+            records,
+            refs_local,
+            nn_table,
+            config,
+            int(args.chunked_batches),
+            int(getattr(args, "max_points_per_batch", 0)),
+            progress_callback=progress_callback,
+            debug_state=debug_state,
+            cancel_requested=cancel_requested,
+        )
 
     from .core.pipeline import PipelineCancelled, run_dense_pipeline
 
@@ -512,6 +761,24 @@ def build_argparser():
         type=int,
         default=0,
         help="Optional cap on total points (0 = unlimited)",
+    )
+    ap.add_argument(
+        "--chunked_batches",
+        type=int,
+        default=1,
+        help=(
+            "Split selected reference views into this many RAM-safer chunks. "
+            "Neighbors remain global; <=1 keeps the legacy single-pass mode."
+        ),
+    )
+    ap.add_argument(
+        "--max_points_per_batch",
+        type=int,
+        default=0,
+        help=(
+            "Optional per-chunk point cap before chunk files are merged "
+            "(0 = no per-chunk cap; final --max_points still applies globally)."
+        ),
     )
     ap.add_argument(
         "--min_track_length",

--- a/densify.py
+++ b/densify.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 import argparse
 import gc
+import hashlib
+import json
 import os
 import sys
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import lichtfeld as lf
 import numpy as np
@@ -240,10 +242,117 @@ def _chunk_output_dir(output_path: str) -> str:
     return str(output.with_suffix("")) + "_chunks"
 
 
-def _save_npz_chunk(path_out: str, xyz: np.ndarray, rgb: np.ndarray) -> int:
+def _jsonable_array(value: np.ndarray) -> List[Any]:
+    return np.asarray(value).tolist()
+
+
+def _camera_record_fingerprint(record: CameraRecord) -> Dict[str, Any]:
+    camera = getattr(record, "colmap_camera", None)
+    camera_model = ""
+    camera_params: List[float] = []
+    if camera is not None:
+        camera_model = str(getattr(camera, "model", ""))
+        if hasattr(getattr(camera, "model", None), "name"):
+            camera_model = str(camera.model.name)
+        if hasattr(camera, "params"):
+            camera_params = [float(v) for v in np.asarray(camera.params, dtype=np.float64).reshape(-1)]
+
+    return {
+        "uid": int(record.uid),
+        "image_path": str(record.image_path),
+        "mask_path": str(record.mask_path) if record.mask_path is not None else None,
+        "width": int(record.width),
+        "height": int(record.height),
+        "K": _jsonable_array(np.asarray(record.K, dtype=np.float64)),
+        "R": _jsonable_array(np.asarray(record.R, dtype=np.float64)),
+        "t": _jsonable_array(np.asarray(record.t, dtype=np.float64)),
+        "C": _jsonable_array(np.asarray(record.C, dtype=np.float64)),
+        "camera_model": camera_model,
+        "camera_params": camera_params,
+    }
+
+
+def _chunk_run_manifest(
+    records: Sequence[CameraRecord],
+    refs_local: Sequence[int],
+    nn_table: np.ndarray,
+    config: DensePipelineConfig,
+    chunk_count: int,
+    max_points_per_batch: int,
+    chunks: Sequence[Sequence[int]],
+) -> Dict[str, Any]:
+    refs = [int(v) for v in refs_local]
+    nn_table_arr = np.asarray(nn_table)
+    ref_neighbor_rows = {
+        str(ref): [int(v) for v in nn_table_arr[int(ref)].reshape(-1).tolist()]
+        for ref in refs
+    }
+    return {
+        "schema": "densification.chunked_resume.v1",
+        "records": [_camera_record_fingerprint(record) for record in records],
+        "refs_local": refs,
+        "ref_neighbor_rows": ref_neighbor_rows,
+        "chunks": [[int(v) for v in chunk] for chunk in chunks],
+        "options": {
+            "roma_setting": str(config.roma_setting),
+            "num_refs": float(config.num_refs),
+            "nns_per_ref": int(config.nns_per_ref),
+            "matches_per_ref": int(config.matches_per_ref),
+            "certainty_thresh": float(config.certainty_thresh),
+            "reproj_thresh": float(config.reproj_thresh),
+            "sampson_thresh": float(config.sampson_thresh),
+            "min_parallax_deg": float(config.min_parallax_deg),
+            "max_points": int(config.max_points),
+            "min_track_length": int(config.min_track_length),
+            "no_filter": bool(config.no_filter),
+            "use_masks": bool(config.use_masks),
+            "voxel_size": float(config.voxel_size),
+            "seed": int(config.seed),
+            "prefetch_packages": int(config.prefetch_packages),
+            "pack_workers": int(config.pack_workers),
+            "chunk_count": int(chunk_count),
+            "max_points_per_batch": int(max_points_per_batch),
+        },
+    }
+
+
+def _canonical_json(data: Dict[str, Any]) -> str:
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _chunk_run_fingerprint(manifest: Dict[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(manifest).encode("utf-8")).hexdigest()
+
+
+def _chunk_metadata(
+    manifest: Dict[str, Any],
+    fingerprint: str,
+    chunk_idx: int,
+    chunk_refs: Sequence[int],
+) -> Dict[str, Any]:
+    return {
+        "schema": "densification.chunk.v1",
+        "run_fingerprint": fingerprint,
+        "run_manifest": manifest,
+        "chunk_index": int(chunk_idx),
+        "chunk_refs": [int(v) for v in chunk_refs],
+    }
+
+
+def _save_npz_chunk(
+    path_out: str,
+    xyz: np.ndarray,
+    rgb: np.ndarray,
+    metadata: Dict[str, Any],
+) -> int:
     os.makedirs(os.path.dirname(path_out), exist_ok=True)
     rgb_uint8 = to_uint8_rgb(rgb)
-    np.savez(path_out, xyz=xyz.astype(np.float32, copy=False), rgb=rgb_uint8)
+    np.savez(
+        path_out,
+        xyz=xyz.astype(np.float32, copy=False),
+        rgb=rgb_uint8,
+        metadata_json=np.asarray(_canonical_json(metadata)),
+    )
     return int(xyz.shape[0])
 
 
@@ -252,7 +361,7 @@ def _npz_chunk_count(path_in: str) -> int:
         return int(data["xyz"].shape[0])
 
 
-def _load_existing_chunk(path_in: str) -> Optional[int]:
+def _load_existing_chunk(path_in: str, expected_metadata: Dict[str, Any]) -> Optional[int]:
     if not os.path.isfile(path_in):
         return None
     try:
@@ -265,9 +374,18 @@ def _load_existing_chunk(path_in: str) -> Optional[int]:
                 return None
             if rgb.shape[0] != xyz.shape[0]:
                 return None
-            count = int(xyz.shape[0])
-            if count <= 0:
+            if "metadata_json" not in data:
+                lf.log.warn(f"Could not reuse existing chunk {path_in}: missing chunk metadata")
                 return None
+            try:
+                metadata = json.loads(str(data["metadata_json"].item()))
+            except Exception:
+                lf.log.warn(f"Could not reuse existing chunk {path_in}: invalid chunk metadata")
+                return None
+            if metadata != expected_metadata:
+                lf.log.warn(f"Could not reuse existing chunk {path_in}: fingerprint mismatch")
+                return None
+            count = int(xyz.shape[0])
             return count
     except Exception as exc:
         lf.log.warn(f"Could not reuse existing chunk {path_in}: {exc}")
@@ -380,9 +498,20 @@ def _run_dense_pipeline_chunked(
     chunks = _split_refs_local(refs_local, chunk_count)
     chunk_dir = _chunk_output_dir(config.output_path)
     os.makedirs(chunk_dir, exist_ok=True)
+    run_manifest = _chunk_run_manifest(
+        records,
+        refs_local,
+        nn_table,
+        config,
+        chunk_count,
+        max_points_per_batch,
+        chunks,
+    )
+    run_fingerprint = _chunk_run_fingerprint(run_manifest)
     lf.log.info(
         f"Chunked densification enabled: {len(chunks)} chunks, "
-        f"global refs={len(refs_local)}, neighbors remain global"
+        f"global refs={len(refs_local)}, neighbors remain global, "
+        f"fingerprint={run_fingerprint[:12]}"
     )
     if progress_callback:
         progress_callback(5.0, f"Chunked densification: {len(chunks)} chunks")
@@ -391,8 +520,9 @@ def _run_dense_pipeline_chunked(
     chunk_counts: List[int] = []
     for chunk_idx, chunk_refs in enumerate(chunks, start=1):
         chunk_path = os.path.join(chunk_dir, f"chunk_{chunk_idx:04d}.npz")
+        chunk_metadata = _chunk_metadata(run_manifest, run_fingerprint, chunk_idx, chunk_refs)
         if resume_chunks:
-            existing_count = _load_existing_chunk(chunk_path)
+            existing_count = _load_existing_chunk(chunk_path, chunk_metadata)
             if existing_count is not None:
                 chunk_paths.append(chunk_path)
                 chunk_counts.append(existing_count)
@@ -440,9 +570,11 @@ def _run_dense_pipeline_chunked(
                 progress_callback(0.0, "Cancelled")
             return 2
         except RuntimeError as exc:
-            lf.log.warn(f"Chunk {chunk_idx}/{len(chunks)} failed: {exc}")
             gc.collect()
-            continue
+            raise RuntimeError(
+                f"Chunk {chunk_idx}/{len(chunks)} failed; final PLY was not written. "
+                "Completed chunks remain available for --resume_chunks."
+            ) from exc
 
         tracks_before = [list(track) for track in result.tracks]
         xyz, rgb, err, tracks = _apply_track_filter(
@@ -460,6 +592,13 @@ def _run_dense_pipeline_chunked(
         )
         if xyz.shape[0] == 0:
             lf.log.warn(f"Chunk {chunk_idx}/{len(chunks)} produced no points after filtering.")
+            empty_rgb = np.empty((0, 3), dtype=np.uint8)
+            count = _save_npz_chunk(chunk_path, xyz, empty_rgb, chunk_metadata)
+            chunk_paths.append(chunk_path)
+            chunk_counts.append(count)
+            lf.log.info(f"Chunk {chunk_idx}/{len(chunks)} saved empty completion marker -> {chunk_path}")
+            del result, tracks_before, xyz, rgb, err, tracks
+            gc.collect()
             continue
 
         if max_points_per_batch > 0:
@@ -472,7 +611,7 @@ def _run_dense_pipeline_chunked(
                 config.seed + chunk_idx,
             )
 
-        count = _save_npz_chunk(chunk_path, xyz, rgb)
+        count = _save_npz_chunk(chunk_path, xyz, rgb, chunk_metadata)
         chunk_paths.append(chunk_path)
         chunk_counts.append(count)
         lf.log.info(f"Chunk {chunk_idx}/{len(chunks)} saved {count:,} points -> {chunk_path}")
@@ -485,15 +624,18 @@ def _run_dense_pipeline_chunked(
 
     if progress_callback:
         progress_callback(94.0, "Merging chunked point output...")
+    output_path = config.output_path
+    tmp_output_path = output_path + ".tmp"
     output_count, total_count = _write_ply_from_npz_chunks(
-        config.output_path,
+        tmp_output_path,
         chunk_paths,
         config.max_points,
         config.seed,
     )
+    os.replace(tmp_output_path, output_path)
     lf.log.info(
         f"Chunked dense reconstruction finished: wrote {output_count:,}/{total_count:,} "
-        f"points from {len(chunk_paths)} chunks -> {config.output_path}"
+        f"points from {len(chunk_paths)} chunks -> {output_path}"
     )
     lf.log.info(
         "Chunk point counts: "
@@ -826,8 +968,9 @@ def build_argparser():
         "--resume_chunks",
         action="store_true",
         help=(
-            "Reuse valid existing chunk_XXXX.npz files in chunked mode and "
-            "continue with the first missing or invalid chunk."
+            "Reuse existing chunk_XXXX.npz files only when their saved run "
+            "fingerprint matches the current reconstruction, chunk assignment, "
+            "and point-generating options."
         ),
     )
     ap.add_argument(

--- a/densify.py
+++ b/densify.py
@@ -252,6 +252,28 @@ def _npz_chunk_count(path_in: str) -> int:
         return int(data["xyz"].shape[0])
 
 
+def _load_existing_chunk(path_in: str) -> Optional[int]:
+    if not os.path.isfile(path_in):
+        return None
+    try:
+        with np.load(path_in) as data:
+            xyz = data["xyz"]
+            rgb = data["rgb"]
+            if xyz.ndim != 2 or xyz.shape[1] != 3:
+                return None
+            if rgb.ndim != 2 or rgb.shape[1] != 3:
+                return None
+            if rgb.shape[0] != xyz.shape[0]:
+                return None
+            count = int(xyz.shape[0])
+            if count <= 0:
+                return None
+            return count
+    except Exception as exc:
+        lf.log.warn(f"Could not reuse existing chunk {path_in}: {exc}")
+        return None
+
+
 def _write_ply_vertices(file_obj, xyz: np.ndarray, rgb_uint8: np.ndarray) -> None:
     if xyz.shape[0] == 0:
         return
@@ -345,6 +367,7 @@ def _run_dense_pipeline_chunked(
     config: DensePipelineConfig,
     chunk_count: int,
     max_points_per_batch: int,
+    resume_chunks: bool,
     progress_callback: Optional[Callable[[float, str], None]],
     debug_state=None,
     cancel_requested: Optional[Callable[[], bool]] = None,
@@ -367,6 +390,23 @@ def _run_dense_pipeline_chunked(
     chunk_paths: List[str] = []
     chunk_counts: List[int] = []
     for chunk_idx, chunk_refs in enumerate(chunks, start=1):
+        chunk_path = os.path.join(chunk_dir, f"chunk_{chunk_idx:04d}.npz")
+        if resume_chunks:
+            existing_count = _load_existing_chunk(chunk_path)
+            if existing_count is not None:
+                chunk_paths.append(chunk_path)
+                chunk_counts.append(existing_count)
+                lf.log.info(
+                    f"Chunk {chunk_idx}/{len(chunks)} reused "
+                    f"{existing_count:,} points -> {chunk_path}"
+                )
+                if progress_callback:
+                    progress_callback(
+                        5.0 + (chunk_idx / max(1, len(chunks))) * 88.0,
+                        f"Reused chunk {chunk_idx}/{len(chunks)} ({existing_count:,} points)",
+                    )
+                continue
+
         if _cancel_requested(cancel_requested):
             if progress_callback:
                 progress_callback(0.0, "Cancelled")
@@ -432,7 +472,6 @@ def _run_dense_pipeline_chunked(
                 config.seed + chunk_idx,
             )
 
-        chunk_path = os.path.join(chunk_dir, f"chunk_{chunk_idx:04d}.npz")
         count = _save_npz_chunk(chunk_path, xyz, rgb)
         chunk_paths.append(chunk_path)
         chunk_counts.append(count)
@@ -511,6 +550,7 @@ def dense_init(
             config,
             int(args.chunked_batches),
             int(getattr(args, "max_points_per_batch", 0)),
+            bool(getattr(args, "resume_chunks", False)),
             progress_callback=progress_callback,
             debug_state=debug_state,
             cancel_requested=cancel_requested,
@@ -780,6 +820,14 @@ def build_argparser():
         help=(
             "Optional per-chunk point cap before chunk files are merged "
             "(0 = no per-chunk cap; final --max_points still applies globally)."
+        ),
+    )
+    ap.add_argument(
+        "--resume_chunks",
+        action="store_true",
+        help=(
+            "Reuse valid existing chunk_XXXX.npz files in chunked mode and "
+            "continue with the first missing or invalid chunk."
         ),
     )
     ap.add_argument(

--- a/densify.py
+++ b/densify.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Tuple
 
@@ -113,6 +114,7 @@ def _build_camera_records_from_colmap(
                 t=t,
                 P=P,
                 C=C,
+                colmap_camera=cam,
             )
         )
     return records, img_ids
@@ -533,6 +535,34 @@ def build_argparser():
     return ap
 
 
+def _cli_progress_callback() -> Callable[[float, str], None]:
+    last = {"pct": None, "msg": None, "matching_bucket": -1, "matching_time": 0.0}
+
+    def _report(pct: float, msg: str) -> None:
+        pct_f = float(pct)
+        msg_s = str(msg)
+        is_matching = msg_s.startswith("Matching ")
+        if is_matching:
+            now = time.time()
+            bucket = int(pct_f)
+            should_print = (
+                bucket > int(last["matching_bucket"])
+                or now - float(last["matching_time"]) >= 10.0
+                or pct_f >= 89.9
+            )
+            if not should_print:
+                return
+            last["matching_bucket"] = bucket
+            last["matching_time"] = now
+        if last["pct"] == pct_f and last["msg"] == msg_s:
+            return
+        last["pct"] = pct_f
+        last["msg"] = msg_s
+        print(f"[{pct_f:6.2f}%] {msg_s}", flush=True)
+
+    return _report
+
+
 if __name__ == "__main__":
     cli_args = build_argparser().parse_args()
-    raise SystemExit(dense_init(cli_args))
+    raise SystemExit(dense_init(cli_args, progress_callback=_cli_progress_callback()))


### PR DESCRIPTION
## Summary

This PR adds CLI-oriented densification improvements for larger and distorted-camera datasets:

- add distortion-aware triangulation/projection support for `THIN_PRISM_FISHEYE` COLMAP cameras
- skip Sampson filtering for distorted/fisheye camera pairs where the pinhole epipolar approximation is not reliable
- fix distortion-aware triangulation indexing after valid-UV filtering
- add RAM-safer chunked CLI densification with `--chunked_batches`
- add optional per-chunk caps via `--max_points_per_batch`
- add resumable chunked runs via `--resume_chunks`
- skip expensive visibility-based reference selection when all cameras are selected

## Motivation

Large datasets can require tens of millions of generated points. The existing single-pass CLI path accumulates the full dense output before writing, which can create high RAM pressure and makes long runs fragile if interrupted.

The chunked mode splits selected reference views into deterministic `chunk_XXXX.npz` files, then streams a final binary PLY from those chunks. This allows long CLI runs to be resumed after interruption and keeps already completed chunks reusable.

The distorted-camera changes are needed for COLMAP exports using `THIN_PRISM_FISHEYE`, where plain pinhole projection assumptions can reject otherwise valid correspondences.

## User impact

New CLI flags:

```bash
--chunked_batches N
--max_points_per_batch N
--resume_chunks
```

Example:

```bash
python -m densification.densify \
  --scene_root /path/to/scene \
  --images_subdir images \
  --out_name /path/to/output/points3D_dense.ply \
  --roma_setting fast \
  --num_refs 0.75 \
  --nns_per_ref 4 \
  --matches_per_ref 12000 \
  --max_points 0 \
  --chunked_batches 5 \
  --max_points_per_batch 10000000 \
  --resume_chunks \
  --seed 0
```

Legacy behavior is preserved when `--chunked_batches <= 1`.

## Validation

- `python3 -m py_compile densify.py`
- `git diff --check`
- CLI help confirms the new flags are exposed
- smoke-tested chunked output on a small dataset:
  - 4 chunks generated successfully
  - final PLY wrote 17,346 points
  - RGB values were verified in the final binary PLY
- smoke-tested `--resume_chunks`:
  - all existing chunks reused and directly merged
  - one missing chunk case reused existing chunks and recomputed only the missing chunk
- tested a larger chunked run path on an Agisoft/COLMAP-style dataset:
  - existing completed chunks could be merged into a partial PLY
  - RGB values were preserved in the merged binary PLY

